### PR TITLE
Write records as they come

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,6 @@ Built with the [Meltano SDK](https://sdk.meltano.com) for Singer Taps and Target
 | timestamp_format         | False    | %Y-%m-%d.T%H%M%S | A python format string to use when outputting the `{timestamp}` string. For reference, see: https://docs.python.org/3/library/datetime.html#strftime-and-strptime-format-codes |
 | timestamp_timezone       | False    | UTC     | The timezone code or name to use when generating `{timestamp}` and `{datestamp}`. Defaults to 'UTC'. For a list of possible values, please see: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones |
 | stream_maps              | False    | None    | Allows inline stream transformations and aliasing. For more information see: https://sdk.meltano.com/en/latest/stream_maps.html |
-| record_sort_property_name| False    | None    | A property in the record which will be used as a sort key.<BR/><BR/>If this property is omitted, records will not be sorted. |
-| overwrite_behavior       | False    | replace_file | Determines the overwrite behavior if destination file already exists. Must be one of the following string values: <BR/><BR/>- `append_records` (default) - append records at the insertion point<BR/>- `replace_file` - replace entire file using `default_CSV_template` |
 | escape_characters        | False    | None    | A string of characters to escape when writing CSV files. |
 
 A full list of supported settings and capabilities is available by running: `target-csv --about`

--- a/target_csv/serialization.py
+++ b/target_csv/serialization.py
@@ -3,6 +3,28 @@ from pathlib import Path
 from typing import Any, List
 
 
+def write_csv_header(filepath: Path, schema: dict, **kwargs: Any) -> None:
+    """Write a CSV header."""
+    if "properties" not in schema:
+        raise ValueError("Stream's schema has no properties defined.")
+
+    keys: List[str] = list(schema["properties"].keys())
+    with open(filepath, "w", encoding="utf-8", newline="") as fp:
+        writer = csv.DictWriter(fp, fieldnames=keys, dialect="excel", **kwargs)
+        writer.writeheader()
+
+
+def write_csv_row(filepath: Path, record: dict, schema: dict, **kwargs: Any) -> None:
+    """Write a CSV row."""
+    if "properties" not in schema:
+        raise ValueError("Stream's schema has no properties defined.")
+
+    keys: List[str] = list(schema["properties"].keys())
+    with open(filepath, "a", encoding="utf-8", newline="") as fp:
+        writer = csv.DictWriter(fp, fieldnames=keys, dialect="excel", **kwargs)
+        writer.writerow(record)
+
+
 def write_csv(filepath: Path, records: List[dict], schema: dict, **kwargs: Any) -> int:
     """Write a CSV file."""
     if "properties" not in schema:

--- a/target_csv/target.py
+++ b/target_csv/target.py
@@ -87,25 +87,6 @@ class TargetCSV(Target):
             ),
         ),
         th.Property(
-            "record_sort_property_name",
-            th.StringType,
-            description=(
-                "A property in the record which will be used as a sort key.\n\n"
-                "If this property is omitted, records will not be sorted."
-            ),
-        ),
-        th.Property(
-            "overwrite_behavior",
-            th.StringType,
-            description=(
-                "Determines the overwrite behavior if destination file already exists. "
-                "Must be one of the following string values: \n\n"
-                "- `append_records` (default) - append records at the insertion point\n"
-                "- `replace_file` - replace entire file using `default_CSV_template`\n"
-            ),
-            default="replace_file",
-        ),
-        th.Property(
             "escape_character",
             th.StringType,
             description="The character to use for escaping special characters.",


### PR DESCRIPTION
The default tap stores the entire table in-memory as a dict, meaning processes can run out of memory with not-so-big tables (on the order of 1-2 gigs)

So, write the lines out as they come