### PR TITLE
Change to write every record as they come in, not building things up in memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,6 @@ Built with the [Meltano SDK](https://sdk.meltano.com) for Singer Taps and Target
 | timestamp_format         | False    | %Y-%m-%d.T%H%M%S | A python format string to use when outputting the `{timestamp}` string. For reference, see: https://docs.python.org/3/library/datetime.html#strftime-and-strptime-format-codes |
 | timestamp_timezone       | False    | UTC     | The timezone code or name to use when generating `{timestamp}` and `{datestamp}`. Defaults to 'UTC'. For a list of possible values, please see: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones |
 | stream_maps              | False    | None    | Allows inline stream transformations and aliasing. For more information see: https://sdk.meltano.com/en/latest/stream_maps.html |
-| record_sort_property_name| False    | None    | A property in the record which will be used as a sort key.<BR/><BR/>If this property is omitted, records will not be sorted. |
-| overwrite_behavior       | False    | replace_file | Determines the overwrite behavior if destination file already exists. Must be one of the following string values: <BR/><BR/>- `append_records` (default) - append records at the insertion point<BR/>- `replace_file` - replace entire file using `default_CSV_template`
- |
 
 A full list of supported settings and capabilities is available by running: `target-csv --about`
 

--- a/target_csv/serialization.py
+++ b/target_csv/serialization.py
@@ -1,6 +1,28 @@
 import csv  # noqa: D100
 from pathlib import Path
-from typing import List
+from typing import List, Any
+
+
+def write_csv_header(filepath: Path, schema: dict, **kwargs: Any) -> None:
+    """Write a CSV header."""
+    if "properties" not in schema:
+        raise ValueError("Stream's schema has no properties defined.")
+
+    keys: List[str] = list(schema["properties"].keys())
+    with open(filepath, "w", encoding="utf-8", newline="") as fp:
+        writer = csv.DictWriter(fp, fieldnames=keys, dialect="excel", **kwargs)
+        writer.writeheader()
+
+
+def write_csv_row(filepath: Path, record: dict, schema: dict, **kwargs: Any) -> None:
+    """Write a CSV row."""
+    if "properties" not in schema:
+        raise ValueError("Stream's schema has no properties defined.")
+
+    keys: List[str] = list(schema["properties"].keys())
+    with open(filepath, "a", encoding="utf-8", newline="") as fp:
+        writer = csv.DictWriter(fp, fieldnames=keys, dialect="excel", **kwargs)
+        writer.writerow(record)
 
 
 def write_csv(filepath: Path, records: List[dict], schema: dict) -> int:

--- a/target_csv/sinks.py
+++ b/target_csv/sinks.py
@@ -7,15 +7,16 @@ from typing import Any, Dict, List, Optional
 
 import pytz
 from singer_sdk import PluginBase
-from singer_sdk.sinks import BatchSink
+from singer_sdk.sinks import RecordSink
 
-from target_csv.serialization import write_csv
+from target_csv.serialization import write_csv, write_csv_header, write_csv_row
 
 
-class CSVSink(BatchSink):
+class CSVSink(RecordSink):
     """CSV target sink class."""
 
     max_size = sys.maxsize  # We want all records in one batch
+    wrote_header = False
 
     def __init__(  # noqa: D107
         self,
@@ -57,27 +58,8 @@ class CSVSink(BatchSink):
 
         return Path(result)
 
-    def process_batch(self, context: dict) -> None:
-        """Write out any prepped records and return once fully written."""
-        output_file: Path = self.destination_path
-        self.logger.info(f"Writing to destination file '{output_file.resolve()}'...")
-        new_contents: dict  # noqa: F842
-        create_new = (
-            self.config["overwrite_behavior"] == "replace_file"
-            or not output_file.exists()
-        )
-        if not create_new:
-            raise NotImplementedError("Append mode is not yet supported.")
-
-        if not isinstance(context["records"], list):
-            self.logger.warning(f"No values in {self.stream_name} records collection.")
-            context["records"] = []
-
-        records: List[Dict[str, Any]] = context["records"]
-        if "record_sort_property_name" in self.config:
-            sort_property_name = self.config["record_sort_property_name"]
-            records = sorted(records, key=lambda x: x[sort_property_name])
-
-        self.logger.info(f"Writing {len(context['records'])} records to file...")
-
-        write_csv(output_file, context["records"], self.schema)
+    def process_record(self, record: dict, context: dict) -> None:
+        if not self.wrote_header:
+            write_csv_header(self.destination_path, self.schema)
+            self.wrote_header = True
+        write_csv_row(self.destination_path, record, self.schema)

--- a/target_csv/target.py
+++ b/target_csv/target.py
@@ -73,24 +73,5 @@ class TargetCSV(Target):
                 "https://sdk.meltano.com/en/latest/stream_maps.html"
             ),
         ),
-        th.Property(
-            "record_sort_property_name",
-            th.StringType,
-            description=(
-                "A property in the record which will be used as a sort key.\n\n"
-                "If this property is omitted, records will not be sorted."
-            ),
-        ),
-        th.Property(
-            "overwrite_behavior",
-            th.StringType,
-            description=(
-                "Determines the overwrite behavior if destination file already exists. "
-                "Must be one of the following string values: \n\n"
-                "- `append_records` (default) - append records at the insertion point\n"
-                "- `replace_file` - replace entire file using `default_CSV_template`\n"
-            ),
-            default="replace_file",
-        ),
     ).to_dict()
     default_sink_class = CSVSink


### PR DESCRIPTION
Change to write every record as they come in, not building things up in memory

The latter tends to run out of memory with large datasets, i.e. the ones we care about

A previous version of the PR broke Google Ads, so switch to this base instead

https://github.com/akkio-inc/target-csv/pull/1 - bad